### PR TITLE
Deploy to new namespace

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -65,8 +65,8 @@ jobs:
       - uses: bcgov-nr/action-deployer-openshift@v1.0.2
         with:
           file: ${{ matrix.file }}
-          oc_namespace: ${{ secrets.OC_NAMESPACE }}
-          oc_server: ${{ secrets.OC_SERVER }}
+          oc_namespace: ${{ vars.OC_NAMESPACE }}
+          oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           parameters:

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - name: Remove OpenShift artifacts
         run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }}
+          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
+          oc project ${{ vars.OC_NAMESPACE }}
 
           # Remove old build runs, build pods and deployment pods
           oc delete all,pvc,secret -l app=${{ github.event.repository.name }}-${{ github.event.number }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -90,8 +90,8 @@ jobs:
       - uses: bcgov-nr/action-deployer-openshift@v1.0.2
         with:
           file: ${{ matrix.file }}
-          oc_namespace: ${{ secrets.OC_NAMESPACE }}
-          oc_server: ${{ secrets.OC_SERVER }}
+          oc_namespace: ${{ vars.OC_NAMESPACE }}
+          oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           penetration_test: false

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -34,8 +34,8 @@ jobs:
       - uses: bcgov-nr/action-deployer-openshift@v1.0.2
         with:
           file: ${{ matrix.file }}
-          oc_namespace: ${{ secrets.OC_NAMESPACE }}
-          oc_server: ${{ secrets.OC_SERVER }}
+          oc_namespace: ${{ vars.OC_NAMESPACE }}
+          oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           parameters:

--- a/.github/workflows/pubcode-crawler-on-scheduler.yml
+++ b/.github/workflows/pubcode-crawler-on-scheduler.yml
@@ -46,8 +46,8 @@ jobs:
           GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_NAMES: ${{ github.event.inputs.REPO_NAMES }}
         run: |
-          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-          oc project ${{ secrets.OC_NAMESPACE }}
+          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
+          oc project ${{ vars.OC_NAMESPACE }}
 
           # Get API key
           API_KEY=$(oc get secrets/pubcode-prod-api --template={{.data.api_key}} | base64 -d)


### PR DESCRIPTION
Any old change to trigger a new deployment now that this repository is pointing to the new dedicated namespace.

This PR switches a few secrets to use variables instead, since that's a new-ish feature.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://pubcode-178-api.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://pubcode-178.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/pubcode/actions/workflows/merge-main.yml)