### PR TITLE
Reduce DEV PVC size

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -78,6 +78,7 @@ jobs:
           - name: database
             file: database/openshift.deploy.yml
             overwrite: false
+            parameters: -p DB_PVC_SIZE=50Mi
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true


### PR DESCRIPTION
Reduce PVC size for DEV PRs to prevent running out of space/allocations.