### PR TITLE
update caddy to 2.6.4 alpine

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        browser: [ chrome, firefox, edge ]
+        browser: [ chrome, edge ]
     steps:
       - uses: actions/checkout@v3
         name: Checkout

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -91,7 +91,7 @@ jobs:
           - name: database
             file: database/openshift.deploy.yml
             overwrite: false
-            parameters: -p DB_PVC_SIZE=500Mi
+            parameters: -p DB_PVC_SIZE=100Mi
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 This contains schema definitions for yml and a web application to assist end users to create/edit bcgovpubcode.yml files, store them in a MongoDB database and retrieve them using a Node/Express API.
 
+## FAQ
+Please click [here](https://github.com/bcgov/pubcode/wiki/Frequently-Asked-Questions)
+
 ## Components
 
 1. Database (MongoDB): Stores all bcgovpubcode.yml files, converted to JSON, for each participating repo in the bcgov organization.

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -30,3 +30,9 @@
 		Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
 	}
 }
+
+:3001 {
+  handle /health {
+    respond "OK"
+  }
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,9 +12,8 @@ COPY --from=build /app/dist /app/dist
 
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health || exit 1
 
-# Add CAP_NET_BIND_SERVICE capability
-RUN apk add --no-cache libcap && setcap 'cap_net_bind_service=+ep' /usr/bin/caddy
-
+RUN chmod 777 /usr/bin/caddy /config/caddy
+RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 EXPOSE 3000
 USER 1001
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,8 @@ RUN apk add --no-cache ca-certificates && \
 
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health
 EXPOSE 3000 3001
+
+RUN chmod -R 777 /tmp
 USER 1001
 
-CMD ["caddy", "run"]
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,4 +18,4 @@ HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/healt
 EXPOSE 3000 3001
 USER 1001
 
-CMD sh -c "caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"
+CMD ["caddy", "run"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,16 +4,17 @@ COPY . .
 RUN npm ci --ignore-scripts
 RUN npm run build
 
-FROM caddy:2.6.4-alpine
+FROM caddy:2.6.4-alpine AS caddy-build
 WORKDIR /app
+RUN apk add --no-cache ca-certificates
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /app/dist
 
-
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health || exit 1
-
-RUN chmod 777 /usr/bin/caddy /config/caddy
 RUN caddy fmt --overwrite /etc/caddy/Caddyfile
+
+
+FROM scratch
+COPY --from=caddy-build / /
 EXPOSE 3000
 USER 1001
-CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /app/dist
 
 
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3000
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health || exit 1
 
 # Add CAP_NET_BIND_SERVICE capability
 RUN apk add --no-cache libcap && setcap 'cap_net_bind_service=+ep' /usr/bin/caddy

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN npm ci --ignore-scripts
 RUN npm run build
 
-FROM caddy:2.4.6-alpine
+FROM caddy:2.6.4-alpine
 WORKDIR /app
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /app/dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,8 @@ COPY . .
 RUN npm ci --ignore-scripts && \
     npm run build
 
-FROM caddy:2.7-alpine
+# Caddy
+FROM caddy:2.6.4-alpine
 
 WORKDIR /app
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,11 +9,12 @@ WORKDIR /app
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /app/dist
 
-EXPOSE 3000
-USER 1001
+
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3000
 
 # Add CAP_NET_BIND_SERVICE capability
 RUN apk add --no-cache libcap && setcap 'cap_net_bind_service=+ep' /usr/bin/caddy
 
+EXPOSE 3000
+USER 1001
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,3 +12,8 @@ COPY --from=build /app/dist /app/dist
 EXPOSE 3000
 USER 1001
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3000
+
+# Add CAP_NET_BIND_SERVICE capability
+RUN apk add --no-cache libcap && setcap 'cap_net_bind_service=+ep' /usr/bin/caddy
+
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,4 @@
+# Build static files
 FROM node:alpine AS build
 
 WORKDIR /app
@@ -6,19 +7,17 @@ RUN npm ci --ignore-scripts && \
     npm run build
 
 # Caddy
-FROM caddy:2.6.4-alpine
+FROM caddy:2.7-alpine
 
-WORKDIR /app
-COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
+# Copy static files and config
 COPY --from=build /app/dist /app/dist
+COPY Caddyfile /etc/caddy/Caddyfile
 
+# Packages and caddy format
 RUN apk add --no-cache ca-certificates && \
     caddy fmt --overwrite /etc/caddy/Caddyfile
 
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health
+# Port, health check and non-root user
 EXPOSE 3000 3001
-
-RUN chmod -R 777 /tmp
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health
 USER 1001
-
-CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,16 +1,20 @@
 FROM node:alpine AS build
+
 WORKDIR /app
 COPY . .
-RUN npm ci --ignore-scripts
-RUN npm run build
+RUN npm ci --ignore-scripts && \
+    npm run build
 
 FROM caddy:2.7-alpine
+
+
 WORKDIR /app
-RUN apk add --no-cache ca-certificates
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /app/dist
 
-RUN caddy fmt --overwrite /etc/caddy/Caddyfile
+RUN apk add --no-cache ca-certificates && \
+    caddy fmt --overwrite /etc/caddy/Caddyfile
+
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health || exit 1
 EXPOSE 3000 3001
 USER 1001

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,17 +4,13 @@ COPY . .
 RUN npm ci --ignore-scripts
 RUN npm run build
 
-FROM caddy:2.6.4-alpine AS caddy-build
+FROM caddy:2.7-alpine
 WORKDIR /app
 RUN apk add --no-cache ca-certificates
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /app/dist
 
 RUN caddy fmt --overwrite /etc/caddy/Caddyfile
-
-
-FROM scratch
-COPY --from=caddy-build / /
-EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health || exit 1
+EXPOSE 3000 3001
 USER 1001
-CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,6 @@ RUN npm ci --ignore-scripts && \
 
 FROM caddy:2.7-alpine
 
-
 WORKDIR /app
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /app/dist
@@ -15,6 +14,8 @@ COPY --from=build /app/dist /app/dist
 RUN apk add --no-cache ca-certificates && \
     caddy fmt --overwrite /etc/caddy/Caddyfile
 
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health || exit 1
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health
 EXPOSE 3000 3001
 USER 1001
+
+CMD sh -c "caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -86,6 +86,11 @@ objects:
         spec:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+              securityContext:
+                runAsUser: 1015550005
+                allowPrivilegeEscalation: false
+                capabilities:
+                  add: ["NET_BIND_SERVICE"]
               imagePullPolicy: Always
               name: ${NAME}
               ports:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -87,8 +87,6 @@ objects:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
               securityContext:
-                runAsUser: 1015550005
-                allowPrivilegeEscalation: false
                 capabilities:
                   add: ["NET_BIND_SERVICE"]
               imagePullPolicy: Always

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -100,20 +100,22 @@ objects:
                   memory: ${MEMORY_LIMIT}
               readinessProbe:
                 httpGet:
-                  path: /
-                  port: 3000
+                  path: /health
+                  port: 3001
                   scheme: HTTP
-                initialDelaySeconds: 15
-                periodSeconds: 30
+                initialDelaySeconds: 2
+                periodSeconds: 2
                 timeoutSeconds: 1
+                successThreshold: 1
+                failureThreshold: 30
               livenessProbe:
                 successThreshold: 1
                 failureThreshold: 3
                 httpGet:
-                  path: /
-                  port: 3000
+                  path: /health
+                  port: 3001
                   scheme: HTTP
-                initialDelaySeconds: 15
+                initialDelaySeconds: 30
                 periodSeconds: 30
                 timeoutSeconds: 5
   - apiVersion: v1


### PR DESCRIPTION
This update has been broken for some time on Kubernetes/OpenShift.  It looks like increased security contexts are the problem.


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://pubcode-215-api.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://pubcode-215.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/pubcode/actions/workflows/merge-main.yml)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://pubcode-215-api.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://pubcode-215.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/pubcode/actions/workflows/merge-main.yml)