### PR TITLE
feat: only run greeter on opened or reopened PRs

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   pr-greeting:
     name: PR Greeting
+    if: github.event.action == 'opened' || github.event.action == 'reopened'
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca
       PREFIX: ${{ github.event.repository.name }}-${{ github.event.number }}


### PR DESCRIPTION
Save resources and prevent duplication by running the PR greeter only on opened or reopened.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://pubcode-216-api.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://pubcode-216.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/pubcode/actions/workflows/merge-main.yml)