### PR TITLE
feat: only run greeter on opened or reopened PRs (try 2)

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: PR Greeting
-        uses: bcgov-nr/action-pr-description-add@v0.0.2
+        uses: bcgov-nr/action-pr-description-add@feat/openedReopened
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add_markdown: |


### PR DESCRIPTION
Save resources and prevent duplication by running the PR greeter only on opened or reopened.