### PR TITLE
fix(ci): drop Firefox from Cypress tests

### DIFF
--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        browser: [chrome, firefox]
+        browser: [chrome]
     steps:
       - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v5


### PR DESCRIPTION
Cypress tests for Firefox are failing, holding up PRs.  This skips it.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://pubcode-318-api.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://pubcode-318.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/pubcode/actions/workflows/merge-main.yml)