### PR TITLE
chore(ci): Renovate matchConfidence

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,32 @@
   "description": "Presets from https://github.com/bcgov/nr-renovate",
   "extends": [
     "github>bcgov/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Mend: high confidence minor and patch dependency updates",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchConfidence": [
+        "very high",
+        "high"
+      ]
+    },
+    {
+      "matchConfidence": [
+        "low"
+      ],
+      "dependencyDashboardApproval": true,
+      "commitMessagePrefix": "[LOW] "
+    },
+    {
+      "matchConfidence": [
+        "neutral"
+      ],
+      "dependencyDashboardApproval": true,
+      "commitMessagePrefix": "[NEUTRAL] "
+    }
   ]
 }


### PR DESCRIPTION
Renovate changes using matchConfidence:
- group high and very high updates together
- banish low and neutral updates to the dependency dashboard

This is safe to run, but could result in low or neutral confidence updates going unmerged.  Please make sure to occasionally check Renovate's Dependency Dashboard for this repo.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://pubcode-373-api.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://pubcode-373.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/pubcode/actions/workflows/merge-main.yml)