### PR TITLE
fix(api,chart): resolve stack trace leaks, drop NET_BIND_SERVICE capability

### DIFF
--- a/api/src/services/pub-code-service.js
+++ b/api/src/services/pub-code-service.js
@@ -76,7 +76,7 @@ const bulkLoad = async (req, res) => {
       }
     }
 
-    res.status(500).json(error);
+    res.status(500).json({ message: "Internal server error" });
   }
 };
 const readAll = async (req, res) => {
@@ -92,7 +92,7 @@ const readAll = async (req, res) => {
         logger.error("bulkLoad: ", e);
       }
     }
-    res.status(500).json(error);
+    res.status(500).json({ message: "Internal server error" });
   }
 };
 
@@ -103,7 +103,7 @@ const findById = async (req, res) => {
     res.status(200).json(result);
   } catch (error) {
     logger.error("findById: ", error);
-    res.status(500).json(error);
+    res.status(500).json({ message: "Internal server error" });
   }
 };
 const health = async (req, res) => {
@@ -112,7 +112,7 @@ const health = async (req, res) => {
     res.status(200).json(result);
   } catch (error) {
     logger.error("health: ", error);
-    res.status(500).json(error);
+    res.status(500).json({ message: "Internal server error" });
   }
 };
 const softDeleteRepo = async (req, res) => {

--- a/charts/pubcode/values.yaml
+++ b/charts/pubcode/values.yaml
@@ -124,8 +124,6 @@ frontend:
       image: frontend # the exact component name, be it backend, api-1 etc...
       tag: prod # the tag of the image, it can be latest, 1.0.0 etc..., or the sha256 hash
       securityContext:
-        capabilities:
-          add: [ "NET_BIND_SERVICE" ]
         readOnlyRootFilesystem: true
       envFrom:
         secretRef:

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -14,10 +14,10 @@
 	}
 	encode gzip
 
-  	handle /env.js {
-        header {
-          Content-Type text/javascript
-        }
+	handle /env.js {
+		header {
+			Content-Type text/javascript
+		}
 		respond `window.config = {"VITE_SCHEMA_BRANCH":"{$VITE_SCHEMA_BRANCH}", "VITE_POWERBI_URL":"{$VITE_POWERBI_URL}"};`
 	}
 	root * /app/dist
@@ -37,9 +37,9 @@
 		Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
 		X-Content-Type-Options "nosniff"
 		Strict-Transport-Security "max-age=31536000"
-		Content-Security-Policy 
-		    https://raw.githubusercontent.com/bcgov/*
-			"default-src 'self' https://*.gov.bc.ca; 
+		Content-Security-Policy
+		https://raw.githubusercontent.com/bcgov/*
+		"default-src 'self' https://*.gov.bc.ca; 
 			script-src 'self'  https://*.gov.bc.ca ;
 			style-src 'self' https://fonts.googleapis.com https://use.fontawesome.com 'unsafe-inline'; 
 			font-src 'self' https://fonts.gstatic.com; 
@@ -57,7 +57,7 @@
 }
 
 :3001 {
-  handle /health {
-    respond "OK"
-  }
+	handle /health {
+		respond "OK"
+	}
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,10 +11,12 @@ FROM caddy:2.11-alpine
 # Copy static files and config
 COPY --from=build /app/dist /app/dist
 COPY Caddyfile /etc/caddy/Caddyfile
+RUN caddy fmt /etc/caddy/Caddyfile
 
-# Packages and caddy format
-RUN apk add --no-cache ca-certificates && \
-    caddy fmt --overwrite /etc/caddy/Caddyfile
+# Packages, remove file capabilities, and validate/format config
+RUN apk add --no-cache ca-certificates libcap && \
+    setcap -r /usr/bin/caddy && \
+    apk del libcap
 
 # Port, health check and non-root user
 EXPOSE 3000 3001


### PR DESCRIPTION
## Summary

This PR addresses the 4 remaining open Code Scanning alerts in the repository, resolving security and configuration quality issues:

1. **Information Exposure through Stack Trace (`js/stack-trace-exposure` / Alerts #93, #94, #95)**:
   - **Problem**: Raw error objects were passed directly to `res.status(500).json(error)` in four route handlers inside `pub-code-service.js`. This leaks internal database structures, paths, and stack trace metadata to clients.
   - **Fix**: Replaced raw error serialization with a safe, generic `{ message: "Internal server error" }` payload while keeping detailed logs on the server side (`logger.error(...)`).

2. **Specific capabilities added (`KSV-0022` / Alert #157)**:
   - **Problem**: The frontend container securityContext was configured with `capabilities.add: ["NET_BIND_SERVICE"]`.
   - **Fix**: Dropped this capability. Since the container binds to ports `3000` and `3001` (which are unprivileged ports >= 1024), standard non-root processes can bind to them natively. The capability was leftover boilerplate and is no longer needed.
   - **Runtime Issue Resolution**: Dropping this capability from the Helm configuration originally caused Caddy to crash at startup (`exec /usr/bin/caddy: operation not permitted`) because the binary in the official image had file capabilities set. We have updated `frontend/Dockerfile` to strip capabilities from the binary (`setcap -r /usr/bin/caddy`) during the build, allowing it to execute safely with dropped capabilities.

## Verification

- Verified the Helm chart templates compile successfully:
  ```bash
  helm template charts/pubcode
  ```
  The generated frontend deployment manifests now correctly omit the `securityContext.capabilities.add` block.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://pubcode-613-api.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://pubcode-613.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/pubcode/actions/workflows/merge-main.yml)