### PR TITLE
fix(ci): fix deployment lockups and protect database PVCs

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -116,6 +116,9 @@ jobs:
             if [ -n "${{ inputs.params }}" ]; then
               PARAMS+="${{ inputs.params }}"
             fi
+            if [ -n "${{ inputs.environment }}" ]; then
+              PARAMS+=" --set database.pvc.keep=true"
+            fi
             echo "PARAMS: $PARAMS"
             echo "COMMANDS: $COMMANDS"
             helm upgrade $PARAMS $COMMANDS pubcode.tgz 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@v7
-      - name: Stop pre-existing deployments (status = pending-upgrade)
+      - name: Stop pre-existing deployments (status = pending-*)
         uses: bcgov/action-oc-runner@111868d1fc50db0a40417ba321d865ef5c931bbd # v1.7.0
         with:
           oc_namespace: ${{ vars.oc_namespace }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -116,7 +116,10 @@ jobs:
             if [ -n "${{ inputs.params }}" ]; then
               PARAMS+="${{ inputs.params }}"
             fi
-            if [ -z "${{ inputs.environment }}" ]; then
+            # Force-delete database PVCs ONLY in ephemeral Pull Request (DEV) environments.
+            # For all persistent/formal environments (TEST, PROD, dispatches), we fall back 
+            # to the safe default (keep: true in values.yaml) to prevent accidental data loss.
+            if [ -z "${{ inputs.environment }}" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
               PARAMS+=" --set database.pvc.keep=false"
             fi
             echo "PARAMS: $PARAMS"

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -116,8 +116,8 @@ jobs:
             if [ -n "${{ inputs.params }}" ]; then
               PARAMS+="${{ inputs.params }}"
             fi
-            if [ -n "${{ inputs.environment }}" ]; then
-              PARAMS+=" --set database.pvc.keep=true"
+            if [ -z "${{ inputs.environment }}" ]; then
+              PARAMS+=" --set database.pvc.keep=false"
             fi
             echo "PARAMS: $PARAMS"
             echo "COMMANDS: $COMMANDS"

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -75,8 +75,14 @@ jobs:
             PREVIOUS=$(helm status ${{ inputs.release_name }} -o json | jq .info.status || true)
             if [[ ${PREVIOUS} =~ pending ]]; then
               echo "Rollback triggered"
-              helm rollback ${{ inputs.release_name }} || \
-                helm uninstall ${{ inputs.release_name }}
+              if [ -n "${{ inputs.environment }}" ]; then
+                # Safe rollback only; never uninstall persistent environments (prod/test)
+                helm rollback ${{ inputs.release_name }}
+              else
+                # Fallback to uninstall permitted for ephemeral PR deployments
+                helm rollback ${{ inputs.release_name }} || \
+                  helm uninstall ${{ inputs.release_name }}
+              fi
             fi
 
       - name: Deploy

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -62,8 +62,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@v7
-      - name: Stop pre-existing deployments on PRs (status = pending-upgrade)
-        if: github.event_name == 'pull_request'
+      - name: Stop pre-existing deployments (status = pending-upgrade)
         uses: bcgov/action-oc-runner@111868d1fc50db0a40417ba321d865ef5c931bbd # v1.7.0
         with:
           oc_namespace: ${{ vars.oc_namespace }}
@@ -72,7 +71,7 @@ jobs:
           triggers: ${{ inputs.triggers }}
           commands: |
             set -euo pipefail
-            # Interrupt any previous deployments (PR only)
+            # Interrupt any previous deployments
             PREVIOUS=$(helm status ${{ inputs.release_name }} -o json | jq .info.status || true)
             if [[ ${PREVIOUS} =~ pending ]]; then
               echo "Rollback triggered"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/charts/pubcode/templates/database/templates/pvc.yml
+++ b/charts/pubcode/templates/database/templates/pvc.yml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-database
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.database.pvc.keep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
     {{- include "database.labels" . | nindent 4 }}
 spec:

--- a/charts/pubcode/values.yaml
+++ b/charts/pubcode/values.yaml
@@ -304,4 +304,4 @@ database:
     size: 750Mi
     storageClassName: netapp-file-standard
     accessModes: ReadWriteMany
-    keep: false
+    keep: true

--- a/charts/pubcode/values.yaml
+++ b/charts/pubcode/values.yaml
@@ -304,3 +304,4 @@ database:
     size: 750Mi
     storageClassName: netapp-file-standard
     accessModes: ReadWriteMany
+    keep: false


### PR DESCRIPTION
This PR resolves the ongoing failures in the `Merge to Main` deployment workflow and adds robust protections for database PVCs against accidental data loss.

### Changes Included:
1. **Fix main deploy lockup recovery:** Removed the `pull_request` event gate from the pre-existing deployment cleanup step in `.deploy.yml`. This allows the `Merge to Main` workflow (triggered by `workflow_run` or `workflow_dispatch`) to detect and auto-rollback stuck releases.
2. **Prevent mid-deploy cancellations:** Set `cancel-in-progress` to `false` in the `Merge to Main` concurrency configuration. This prevents GitHub Actions from terminating deployments mid-run and leaving Helm releases in a locked `pending` state.
3. **Fail-safe database PVC retention:**
   - Modified `values.yaml` and `pvc.yml` templates to default to `"helm.sh/resource-policy": keep` for the database PVC.
   - Configured `.deploy.yml` to explicitly override `database.pvc.keep=false` only for ephemeral PR deployments (ensuring we clean up DEV resources).
   - Added a double-safe condition check and inline documentation to prevent accidental deletions on future workflows/dispatches.