### PR TITLE
chore(deps): update bcgov/actions to v0.6.0

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -23,9 +23,9 @@ jobs:
       pull-requests: write
     steps:
       - name: PR Greeting
-        uses: bcgov/actions/pr-description-add@4ad61a784f1c17765b03d8d6de9737c1d3f4c0f2 # v0.5.0
+        uses: bcgov/actions/pr-description-add@8400e9131db281379e19846833b87b9edc6c950d # v0.6.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           add_markdown: |
             ---
 
@@ -52,12 +52,12 @@ jobs:
         package: [api, database, frontend]
     steps:
       - uses: actions/checkout@v7
-      - uses: bcgov/actions/builder-ghcr@4ad61a784f1c17765b03d8d6de9737c1d3f4c0f2 # v0.5.0
+      - uses: bcgov/actions/builder-ghcr@8400e9131db281379e19846833b87b9edc6c950d # v0.6.0
         with:
           package: ${{ matrix.package }}
           tags: ${{ github.event.number || github.sha }}
           tag_fallback: latest
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: shrink/actions-docker-registry-tag@e6aaef25c595b6e0edd18bf4c7dbfea3abd43299 # v5
         with:


### PR DESCRIPTION
## Summary
- Bumps `bcgov/actions` from `v0.5.0` to the restored `v0.6.0` (`8400e9131db281379e19846833b87b9edc6c950d`) in `.github/workflows/pr-open.yml`.
- Renames `github_token` → `token` for `pr-description-add` and `builder-ghcr` (v0.6.0 input name).
- Supersedes Renovate #634, which pinned the dud `v0.6.0` tag before `pr-description-add` was restored.

## Test plan
- [ ] PR Greeting resolves `pr-description-add` and appends the deploy blurb.
- [ ] Builds matrix completes with `builder-ghcr@v0.6.0`.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[API](https://pubcode-636-api.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://pubcode-636.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/pubcode/actions/workflows/merge-main.yml)